### PR TITLE
Fixed: holding jump while in water should move the player up as fast …

### DIFF
--- a/qc/client.qc
+++ b/qc/client.qc
@@ -815,12 +815,20 @@ void() PlayerJump =
 
 	if (self.waterlevel >= 2)
 	{
-		if (self.watertype == CONTENT_WATER)
-			self.velocity_z = 150;
-		else if (self.watertype == CONTENT_SLIME)
-			self.velocity_z = 120;
-		else
-			self.velocity_z = 75;
+		// [Nash] make surfacing speed match forwardmove
+		if (self.waterlevel < 3)
+		{
+			if (self.watertype == CONTENT_WATER)
+				self.velocity_z = 150;
+			else if (self.watertype == CONTENT_SLIME)
+				self.velocity_z = 120;
+			else
+				self.velocity_z = 75;
+		}
+		else if (self.waterlevel == 3)
+		{
+			self.velocity_z = 216.5;
+		}
 
 		// play swimming sound
 		if (self.swim_flag < time)


### PR DESCRIPTION
…as moving forward. You can already bypass the coded limits anyway by pointing the player up and holding forward.

The original values are left intact for the lower waterlevel values, so that jumping out of liquids should remain unchanged.